### PR TITLE
Python3 compatibility problem: raw_input() was renamed to input()

### DIFF
--- a/marker/core.py
+++ b/marker/core.py
@@ -7,19 +7,25 @@ from . import keys
 from . import ui
 from . import readchar
 
+from sys import version_info
+if version_info[0] == 2:
+    keyboard_input = raw_input
+else:
+    keyboard_input = input
+
 
 def mark_command(command, alias):
     ''' Adding a new Mark '''
     command = command.strip()
     if not command:
-        command = raw_input("Command:")
+        command = keyboard_input("Command:")
     else:
         print("command: %s" % command)
     if not command:
         print ("command field is required")
         return
     if not alias:
-        alias = raw_input("Alias?:")
+        alias = keyboard_input("Alias?:")
     else:
         print("alias: %s" % alias)
     if '##' in command or '##' in alias:


### PR DESCRIPTION
Got a bug with python 3.x: https://stackoverflow.com/questions/4915361/whats-the-difference-between-raw-input-and-input-in-python3-x