### PR TITLE
Correct unescaped left brace error

### DIFF
--- a/bin/marker.sh
+++ b/bin/marker.sh
@@ -90,7 +90,7 @@ if [[ -n "$ZSH_VERSION" ]]; then
     }
     # move the cursor the next placeholder 
     function _move_cursor_to_next_placeholder {
-        match=$(echo "$BUFFER" | perl -nle 'print $& if m{{{.+?}}}' | head -n 1)
+        match=$(echo "$BUFFER" | perl -nle 'print $& if m{\{\{.+?\}\}}' | head -n 1)
         if [[ ! -z "$match" ]]; then
             len=${#match}
             match=$(echo "$match" | sed 's/"/\\"/g')


### PR DESCRIPTION
Error occurs on OSX, on usage of Ctrl+T.
Makes marker essentially useless.