### PR TITLE
Fix OSX commands loading

### DIFF
--- a/marker/core.py
+++ b/marker/core.py
@@ -15,9 +15,9 @@ else:
     keyboard_input = input
 
 def get_os():
-    if platform == 'Darwin':
+    if platform.lower() == 'darwin':
         return 'osx'
-    elif platform.startswith('linux'):
+    elif platform.lower().startswith('linux'):
         return 'linux'
     else:
         # throw is better


### PR DESCRIPTION
sys.platform returs 'darwin' not 'Darwin'. This patch fixes that issue and
minimizes same issue for linux based systems.